### PR TITLE
将开机启动和自动检测分拆

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -53,6 +53,7 @@
             this.button2 = new System.Windows.Forms.Button();
             this.button1 = new System.Windows.Forms.Button();
             this.label8 = new System.Windows.Forms.Label();
+            this.checkBoxAutoStart = new System.Windows.Forms.CheckBox();
             this.numericUpDown6 = new System.Windows.Forms.NumericUpDown();
             this.numericUpDown5 = new System.Windows.Forms.NumericUpDown();
             this.label4 = new System.Windows.Forms.Label();
@@ -141,6 +142,7 @@
             this.groupBox1.Controls.Add(this.comboBox4);
             this.groupBox1.Controls.Add(this.button3);
             this.groupBox1.Controls.Add(this.textBox1);
+            this.groupBox1.Controls.Add(this.button2);
             this.groupBox1.Controls.Add(this.comboBox1);
             this.groupBox1.Controls.Add(this.numericUpDown4);
             this.groupBox1.Controls.Add(this.numericUpDown3);
@@ -151,9 +153,9 @@
             this.groupBox1.Controls.Add(this.label3);
             this.groupBox1.Controls.Add(this.label2);
             this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Controls.Add(this.button2);
             this.groupBox1.Controls.Add(this.button1);
             this.groupBox1.Controls.Add(this.label8);
+            this.groupBox1.Controls.Add(this.checkBoxAutoStart);
             this.groupBox1.Location = new System.Drawing.Point(13, 13);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(174, 484);
@@ -164,7 +166,7 @@
             // checkBox5
             // 
             this.checkBox5.AutoSize = true;
-            this.checkBox5.Location = new System.Drawing.Point(91, 428);
+            this.checkBox5.Location = new System.Drawing.Point(91, 430);
             this.checkBox5.Name = "checkBox5";
             this.checkBox5.Size = new System.Drawing.Size(72, 16);
             this.checkBox5.TabIndex = 30;
@@ -396,9 +398,9 @@
             // 
             // button2
             // 
-            this.button2.Location = new System.Drawing.Point(88, 450);
+            this.button2.Location = new System.Drawing.Point(8, 453);
             this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.Size = new System.Drawing.Size(74, 23);
             this.button2.TabIndex = 1;
             this.button2.Text = "高级设置∧";
             this.button2.UseVisualStyleBackColor = true;
@@ -407,9 +409,9 @@
             // button1
             // 
             this.button1.Font = new System.Drawing.Font("宋体", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
-            this.button1.Location = new System.Drawing.Point(7, 428);
+            this.button1.Location = new System.Drawing.Point(7, 425);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 45);
+            this.button1.Size = new System.Drawing.Size(75, 23);
             this.button1.TabIndex = 0;
             this.button1.Text = "▶️ 启动";
             this.button1.UseVisualStyleBackColor = true;
@@ -424,6 +426,15 @@
             this.label8.TabIndex = 9;
             this.label8.Text = "节点池订阅链接(点击编辑)：";
             this.label8.Click += new System.EventHandler(this.textBox1_DoubleClick);
+            // 
+            // checkBoxAutoStart
+            // 
+            this.checkBoxAutoStart.Location = new System.Drawing.Point(91, 455);
+            this.checkBoxAutoStart.Name = "checkBoxAutoStart";
+            this.checkBoxAutoStart.Size = new System.Drawing.Size(72, 20);
+            this.checkBoxAutoStart.TabIndex = 31;
+            this.checkBoxAutoStart.Text = "实时启动";
+            this.checkBoxAutoStart.CheckedChanged += new System.EventHandler(this.checkBoxAutoStart_CheckedChanged);
             // 
             // numericUpDown6
             // 
@@ -1561,4 +1572,6 @@
         private System.Windows.Forms.CheckBox checkBox5;
     }
 }
+
+
 

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -170,7 +170,7 @@
             this.checkBox5.Name = "checkBox5";
             this.checkBox5.Size = new System.Drawing.Size(72, 16);
             this.checkBox5.TabIndex = 30;
-            this.checkBox5.Text = "开机自启";
+            this.checkBox5.Text = "开机启动";
             this.checkBox5.UseVisualStyleBackColor = true;
             this.checkBox5.CheckedChanged += new System.EventHandler(this.checkBox5_CheckedChanged);
             // 
@@ -433,7 +433,7 @@
             this.checkBoxAutoStart.Name = "checkBoxAutoStart";
             this.checkBoxAutoStart.Size = new System.Drawing.Size(72, 20);
             this.checkBoxAutoStart.TabIndex = 31;
-            this.checkBoxAutoStart.Text = "实时启动";
+            this.checkBoxAutoStart.Text = "自动检测";
             this.checkBoxAutoStart.CheckedChanged += new System.EventHandler(this.checkBoxAutoStart_CheckedChanged);
             // 
             // numericUpDown6

--- a/Form1.cs
+++ b/Form1.cs
@@ -37,6 +37,9 @@ namespace subs_check.win.gui
             InitializeComponent();
             originalNotifyIcon = notifyIcon1.Icon;
 
+            toolTip1.SetToolTip(checkBox5, "勾选后，程序将在Windows启动时自动运行");
+            toolTip1.SetToolTip(checkBoxAutoStart, "勾选后，程序启动时将自动开始检查节点");
+
             toolTip1.SetToolTip(checkBoxAutoStart, "勾选后，程序启动时将自动开始检查节点");
 
             toolTip1.SetToolTip(numericUpDown1, "并发线程数：推荐 宽带峰值/50M。");
@@ -156,11 +159,19 @@ namespace subs_check.win.gui
             timer1.Enabled = false;
             if (button2.Text == "高级设置∧") button2_Click(sender, e);
 
-            // 检查实时启动设置
-            if (checkBoxAutoStart.Checked && !CheckCommandLineParameter("-auto"))
+            // 检查开机启动设置
+            if (checkBox5.Checked && !CheckCommandLineParameter("-auto"))
             {
-                button1_Click(this, EventArgs.Empty);
+            // 如果是开机启动，只显示窗口不自动检测
+            this.Show();
+            notifyIcon1.Visible = true;
             }
+
+            // 检查自动检测设置
+            if (checkBoxAutoStart.Checked && !CheckCommandLineParameter("-auto")) 
+         {
+             button1_Click(this, EventArgs.Empty);
+         }
 
             // 检查并创建config文件夹
             string executablePath = System.IO.Path.GetDirectoryName(System.Windows.Forms.Application.ExecutablePath);
@@ -451,17 +462,16 @@ namespace subs_check.win.gui
                     else checkBox4.Checked = false;
 
                     string autoStart = 读取config字符串(config, "auto-start");
-                    if (autoStart != null && autoStart == "true") 
-                        {
-                            checkBoxAutoStart.Checked = true;
-                            Log("从配置中读取到实时启动已启用，将自动检测节点并执行任务");
-                        }
-                         else
-                        {
-                            checkBoxAutoStart.Checked = false;
-                            Log("从配置中读取到实时启动已禁用，将不会自动检测节点，需点击启动执行任务");
-                        }
-
+    if (autoStart != null && autoStart == "true") 
+    {
+        checkBoxAutoStart.Checked = true;
+        Log("从配置中读取到自动检测已启用");
+    }
+    else
+    {
+        checkBoxAutoStart.Checked = false;
+        Log("从配置中读取到自动检测已禁用");
+    }
                     string apikey = 读取config字符串(config, "api-key");
                     if (apikey != null)
                     {
@@ -768,7 +778,6 @@ namespace subs_check.win.gui
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
-
         private void button2_Click(object sender, EventArgs e)
         {
             if (button2.Text == "高级设置∧")

--- a/Form1.cs
+++ b/Form1.cs
@@ -31,10 +31,13 @@ namespace subs_check.win.gui
         string 最新GUI版本号 = "未知版本";
         private string nextCheckTime = null;// 用于存储下次检查时间
         string WebUIapiKey = "CMLiussss";
+        private CheckBox checkBoxAutoStart;
         public Form1()
         {
             InitializeComponent();
             originalNotifyIcon = notifyIcon1.Icon;
+
+            toolTip1.SetToolTip(checkBoxAutoStart, "勾选后，程序启动时将自动开始检查节点");
 
             toolTip1.SetToolTip(numericUpDown1, "并发线程数：推荐 宽带峰值/50M。");
             toolTip1.SetToolTip(numericUpDown2, "检查间隔时间(分钟)：放置后台的时候，下次自动测速的间隔时间。\n\n 双击切换 使用「cron表达式」");
@@ -152,6 +155,13 @@ namespace subs_check.win.gui
         {
             timer1.Enabled = false;
             if (button2.Text == "高级设置∧") button2_Click(sender, e);
+
+            // 检查实时启动设置
+            if (checkBoxAutoStart.Checked && !CheckCommandLineParameter("-auto"))
+            {
+                button1_Click(this, EventArgs.Empty);
+            }
+
             // 检查并创建config文件夹
             string executablePath = System.IO.Path.GetDirectoryName(System.Windows.Forms.Application.ExecutablePath);
             string configFolderPath = System.IO.Path.Combine(executablePath, "config");
@@ -440,6 +450,18 @@ namespace subs_check.win.gui
                     if (enablewebui != null && enablewebui == "true") checkBox4.Checked = true;
                     else checkBox4.Checked = false;
 
+                    string autoStart = 读取config字符串(config, "auto-start");
+                    if (autoStart != null && autoStart == "true") 
+                        {
+                            checkBoxAutoStart.Checked = true;
+                            Log("从配置中读取到实时启动已启用，将自动检测节点并执行任务");
+                        }
+                         else
+                        {
+                            checkBoxAutoStart.Checked = false;
+                            Log("从配置中读取到实时启动已禁用，将不会自动检测节点，需点击启动执行任务");
+                        }
+
                     string apikey = 读取config字符串(config, "api-key");
                     if (apikey != null)
                     {
@@ -586,6 +608,11 @@ namespace subs_check.win.gui
 
                 // 保存sub-store-port
                 config["sub-store-port"] = $@":{numericUpDown7.Value}";
+                // 是否开机自启
+                config["rename-node"] = checkBox1.Checked? "true" : "false";
+                config["gui-auto"] = checkBox5.Checked;//是否开机自启
+                config["auto-start"] = checkBoxAutoStart.Checked; // 程序启动时自动运行
+
 
                 string githubRawPrefix = "https://raw.githubusercontent.com/";
                 if (githubProxyCheck)
@@ -621,7 +648,7 @@ namespace subs_check.win.gui
                 if (System.IO.File.Exists(allyamlFilePath))
                 {
                     subUrls.Add($"http://127.0.0.1:{numericUpDown6.Value}/all.yaml");
-                    Log("已加载上次测试结果。");
+                    //Log("已加载上次测试结果。");
                 }
 
                 if (!string.IsNullOrEmpty(textBox1.Text))
@@ -772,6 +799,11 @@ namespace subs_check.win.gui
                 {
                     string executablePath = Path.GetDirectoryName(Application.ExecutablePath);
                     string allyamlFilePath = Path.Combine(executablePath, "output", "all.yaml");
+                    // 添加检查并提示
+        if (checkBox5.Checked && File.Exists(allyamlFilePath))
+        {
+            Log("已加载上次测试结果。");
+        }
                     button3.Enabled = File.Exists(allyamlFilePath);
                 }
 
@@ -2089,6 +2121,28 @@ namespace subs_check.win.gui
             if (checkBox2.Checked == true) checkBox1.Checked = true;
         }
 
+        private void checkBoxAutoStart_CheckedChanged(object sender, EventArgs e)
+        {
+         if (checkBoxAutoStart.Checked)
+            {
+            Log("已启用实时启动功能，程序启动时将自动开始检查节点");
+
+            // 只有当按钮显示"启动"时才实时启动
+                 if (button1.Text == "▶️ 启动")
+                 {
+                  button1_Click(this, EventArgs.Empty); // 模拟点击启动按钮
+                 }
+             }
+             else
+             {
+            Log("已禁用实时启动功能");
+            }
+
+             // 立即保存设置
+            SaveConfig(false); // 不检查github代理
+            
+        }
+
         private async void timer3_Tick(object sender, EventArgs e)
         {
             if (button1.Text == "⏹️ 停止") 
@@ -2960,7 +3014,7 @@ namespace subs_check.win.gui
                     if (File.Exists(shortcutPath))
                     {
                         File.Delete(shortcutPath);
-                        Log("已移除开机启动项，下次开机将不会自动启动");
+                        Log("已移除开机启动项，下次开机将不会自动运行程序");
                     }
                 }
             }


### PR DESCRIPTION
将开机启动和自动检测分拆。
将功能独立更加灵活。
开机启动：开机后启动电脑后打开电脑并最小化到托盘。
自动检测：打开软件后自动启动，并更新检测节点。