### PR TITLE
添加Github Actions的自动构建配置生成release版本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will build, test, sign and package a WPF or Windows Forms desktop application
+# built on .NET Core.
+# To learn how to migrate your existing application to .NET Core,
+# refer to https://docs.microsoft.com/en-us/dotnet/desktop-wpf/migration/convert-project-from-net-framework
+#
+# To configure this workflow:
+#
+# 1. Configure environment variables
+# GitHub sets default environment variables for every workflow run.
+# Replace the variables relative to your project in the "env" section below.
+#
+# 2. Signing
+# Generate a signing certificate in the Windows Application
+# Packaging Project or add an existing signing certificate to the project.
+# Next, use PowerShell to encode the .pfx file using Base64 encoding
+# by running the following Powershell script to generate the output string:
+#
+# $pfx_cert = Get-Content '.\SigningCertificate.pfx' -Encoding Byte
+# [System.Convert]::ToBase64String($pfx_cert) | Out-File 'SigningCertificate_Encoded.txt'
+#
+# Open the output file, SigningCertificate_Encoded.txt, and copy the
+# string inside. Then, add the string to the repo as a GitHub secret
+# and name it "Base64_Encoded_Pfx."
+# For more information on how to configure your signing certificate for
+# this workflow, refer to https://github.com/microsoft/github-actions-for-desktop-apps#signing
+#
+# Finally, add the signing certificate password to the repo as a secret and name it "Pfx_Key".
+# See "Build the Windows Application Packaging project" below to see how the secret is used.
+#
+# For more information on GitHub Actions, refer to https://github.com/features/actions
+# For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
+# refer to https://github.com/microsoft/github-actions-for-desktop-apps
+
+name: .NET Core Desktop
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+
+    runs-on: windows-latest  # For a list of available runner types, refer to
+                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    env:
+      Solution_Name: your-solution-name                         # Replace with your solution name, i.e. MyWpfApp.sln.
+      Test_Project_Path: your-test-project-path                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
+      Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
+      Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    # Install the .NET Core workload
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v2
+
+    # Execute all unit tests in the solution
+    - name: Execute unit tests
+      run: dotnet test
+
+    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    - name: Restore the application
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+      env:
+        Configuration: ${{ matrix.configuration }}
+
+    # Decode the base 64 encoded pfx and save the Signing_Certificate
+    - name: Decode the pfx
+      run: |
+        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
+        $certificatePath = Join-Path -Path $env:Wap_Project_Directory -ChildPath GitHubActionsWorkflow.pfx
+        [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
+
+    # Create the app package by building and packaging the Windows Application Packaging project
+    - name: Create the app package
+      run: msbuild $env:Wap_Project_Path /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:Appx_Package_Build_Mode /p:AppxBundle=$env:Appx_Bundle /p:PackageCertificateKeyFile=GitHubActionsWorkflow.pfx /p:PackageCertificatePassword=${{ secrets.Pfx_Key }}
+      env:
+        Appx_Bundle: Always
+        Appx_Bundle_Platforms: x86|x64
+        Appx_Package_Build_Mode: StoreUpload
+        Configuration: ${{ matrix.configuration }}
+
+    # Remove the pfx
+    - name: Remove the pfx
+      run: Remove-Item -path $env:Wap_Project_Directory\GitHubActionsWorkflow.pfx
+
+    # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: MSIX Package
+        path: ${{ env.Wap_Project_Directory }}\AppPackages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         Copy-Item "bin\Release\*" -Destination $releaseDir -Recurse
         Compress-Archive -Path "$releaseDir\*" -DestinationPath "SubsCheck-Win-GUI.zip" -Force    
         
-    # Create GitHub Release from tag
+      # Create GitHub Release from tag
     - name: Create GitHub Release
       if: startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v1
@@ -72,7 +72,19 @@ jobs:
         prerelease: false
         generate_release_notes: true
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    # Upload build artifacts (only on tag)
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Delete the tag after successful release
+    - name: Delete tag
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        git config --global user.email "actions@github.com"
+        git config --global user.name "GitHub Actions"
+        git push origin --delete "refs/tags/${{ github.ref_name }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Upload build artifacts
     - name: Upload build artifacts
       if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
 
     # Upload build artifacts (for non-release builds)
     - name: Upload build artifacts
-      if: tartsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v4
       with:
         name: Build Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow will build, test, sign and package a WPF or Windows Forms desktop application
-# built on .NET Core.
-# To learn how to migrate your existing application to .NET Core,
-# refer to https://docs.microsoft.com/en-us/dotnet/desktop-wpf/migration/convert-project-from-net-framework
-#
-# To configure this workflow:
-#
-# 1. Configure environment variables
-# GitHub sets default environment variables for every workflow run.
-# Replace the variables relative to your project in the "env" section below.
-#
-# 2. Signing
-# Generate a signing certificate in the Windows Application
-# Packaging Project or add an existing signing certificate to the project.
-# Next, use PowerShell to encode the .pfx file using Base64 encoding
-# by running the following Powershell script to generate the output string:
-#
-# $pfx_cert = Get-Content '.\SigningCertificate.pfx' -Encoding Byte
-# [System.Convert]::ToBase64String($pfx_cert) | Out-File 'SigningCertificate_Encoded.txt'
-#
-# Open the output file, SigningCertificate_Encoded.txt, and copy the
-# string inside. Then, add the string to the repo as a GitHub secret
-# and name it "Base64_Encoded_Pfx."
-# For more information on how to configure your signing certificate for
-# this workflow, refer to https://github.com/microsoft/github-actions-for-desktop-apps#signing
-#
-# Finally, add the signing certificate password to the repo as a secret and name it "Pfx_Key".
-# See "Build the Windows Application Packaging project" below to see how the secret is used.
-#
-# For more information on GitHub Actions, refer to https://github.com/features/actions
-# For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
-# refer to https://github.com/microsoft/github-actions-for-desktop-apps
-
 name: release CI
 
 on:
@@ -66,19 +28,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 8.0.x
 
     # Add MSBuild to the PATH
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v1.1
 
     # Install NuGet packages
     - name: Install NuGet packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,15 +59,15 @@ jobs:
         $releaseDir = "release-package"
         New-Item -ItemType Directory -Path $releaseDir -Force
         Copy-Item "bin\Release\*" -Destination $releaseDir -Recurse
-        Compress-Archive -Path "$releaseDir\*" -DestinationPath "SubsCheck-Win-GUI.zip" -Force
-
+        Compress-Archive -Path "$releaseDir\*" -DestinationPath "SubsCheck-Win-GUI.zip" -Force    
+        
     # Create GitHub Release from tag
     - name: Create GitHub Release
       if: startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v1
       with:
         files: SubsCheck-Win-GUI.zip
-        name: Release ${{ github.ref_name }}
+        name: ${{ github.ref_name }}
         draft: false
         prerelease: false
         generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,21 +10,13 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        configuration: [Debug]
-        # 在 tag 推送时使用 Release 配置
-        include:
-          - configuration: Release
-            if: startsWith(github.ref, 'refs/tags/v')
-
     runs-on: windows-latest
 
     env:
       Solution_Name: subs-check.win.gui.sln
       Project_Path: subs-check.win.gui.csproj
       Wap_Project_Directory: .
-      Configuration: ${{ matrix.configuration }}
+      Configuration: ${{ startsWith(github.ref, 'refs/tags/v') && 'Release' || 'Debug' }}
 
     steps:
     - name: Checkout
@@ -40,32 +32,27 @@ jobs:
 
     # Add MSBuild to the PATH
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.1
-
-    # Install NuGet packages
+      uses: microsoft/setup-msbuild@v1.1    # Install NuGet packages
     - name: Install NuGet packages
       run: |
-        nuget sources Add -Name "nuget.org" -Source "https://api.nuget.org/v3/index.json"
-        nuget install YamlDotNet -Version 16.0.0
-        mkdir packages
-        xcopy /E /I YamlDotNet* packages\
+        nuget restore $env:Solution_Name
+        nuget install YamlDotNet -Version 16.0.0 -OutputDirectory packages -DependencyVersion Highest
+        Copy-Item "packages\YamlDotNet.*\lib\net45\YamlDotNet.dll" -Destination "bin\$env:Configuration\" -Force
 
     # Restore the application
     - name: Restore the application
-      run: |
-        nuget restore $env:Solution_Name
-        msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
       env:
-        Configuration: ${{ matrix.configuration }}
+        Configuration: ${{ startsWith(github.ref, 'refs/tags/v') && 'Release' || 'Debug' }}
 
     # Build the application
     - name: Build the application
       run: |
         msbuild $env:Solution_Name /p:Configuration=$env:Configuration /p:Platform="Any CPU" /p:DebugSymbols=false /p:DebugType=None
       env:
-        Configuration: ${{ matrix.configuration }}
+        Configuration: ${{ startsWith(github.ref, 'refs/tags/v') && 'Release' || 'Debug' }}
 
-    # Create release package
+    # Create release package (only on tag)
     - name: Create release package
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
@@ -85,12 +72,12 @@ jobs:
         prerelease: false
         generate_release_notes: true
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    # Upload build artifacts (for non-release builds)
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    # Upload build artifacts (only on tag)
     - name: Upload build artifacts
       if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v4
       with:
         name: Build Artifacts
-        path: bin\${{ matrix.configuration }}
+        path: bin\Release
+        compression-level: 9
+        retention-days: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,31 +41,27 @@ name: release CI
 on:
   push:
     branches: [ "master" ]
+    tags:
+      - 'v*'  # 推送 v 开头的 tag 时触发，如 v1.0.0
   pull_request:
     branches: [ "master" ]
-  release:
-    types: [created]
 
 jobs:
-
   build:
-
     strategy:
       matrix:
-        configuration: [Debug, Release]
-        # 仅在非 release 事件时包含 Debug 配置
+        configuration: [Debug]
+        # 在 tag 推送时使用 Release 配置
         include:
-          - configuration: Debug
-            if: github.event_name != 'release'
+          - configuration: Release
+            if: startsWith(github.ref, 'refs/tags/v')
 
-    runs-on: windows-latest  # For a list of available runner types, refer to
-                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    runs-on: windows-latest
 
     env:
-      Solution_Name: subs-check.win.gui.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
-      Test_Project_Path: your-test-project-path                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
-      Wap_Project_Directory: .    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
-      Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
+      Solution_Name: subs-check.win.gui.sln
+      Project_Path: subs-check.win.gui.csproj
+      Wap_Project_Directory: .
       Configuration: ${{ matrix.configuration }}
 
     steps:
@@ -84,26 +80,21 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
 
-    # Execute all unit tests in the solution
-    - name: Execute unit tests
-      if: github.event_name != 'release'
-      run: dotnet test $env:Solution_Name
+    # Install NuGet packages
+    - name: Install NuGet packages
+      run: |
+        nuget sources Add -Name "nuget.org" -Source "https://api.nuget.org/v3/index.json"
+        nuget install YamlDotNet -Version 16.0.0
+        mkdir packages
+        xcopy /E /I YamlDotNet* packages\
 
     # Restore the application
     - name: Restore the application
       run: |
-        dotnet restore $env:Solution_Name
+        nuget restore $env:Solution_Name
         msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
-
-    # Decode the base 64 encoded pfx and save the Signing_Certificate
-    - name: Decode the pfx
-      if: github.event_name == 'release'
-      run: |
-        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
-        $certificatePath = Join-Path -Path $env:Wap_Project_Directory -ChildPath GitHubActionsWorkflow.pfx
-        [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
 
     # Build the application
     - name: Build the application
@@ -114,26 +105,30 @@ jobs:
 
     # Create release package
     - name: Create release package
-      if: github.event_name == 'release'
+      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         $releaseDir = "release-package"
         New-Item -ItemType Directory -Path $releaseDir -Force
-        Copy-Item "bin\${{ matrix.configuration }}\*" -Destination $releaseDir -Recurse
+        Copy-Item "bin\Release\*" -Destination $releaseDir -Recurse
         Compress-Archive -Path "$releaseDir\*" -DestinationPath "SubsCheck-Win-GUI.zip" -Force
 
-    # Upload release artifacts
-    - name: Upload release artifacts
-      if: github.event_name == 'release'
+    # Create GitHub Release from tag
+    - name: Create GitHub Release
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v1
       with:
         files: SubsCheck-Win-GUI.zip
+        name: Release ${{ github.ref_name }}
+        draft: false
+        prerelease: false
+        generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # Upload build artifacts (for non-release builds)
     - name: Upload build artifacts
-      if: github.event_name != 'release'
-      uses: actions/upload-artifact@v4
+      if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/v')
+      uses: actions/upload-artifact@v3
       with:
         name: Build Artifacts
         path: bin\${{ matrix.configuration }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,11 @@ jobs:
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:
-      Solution_Name: your-solution-name                         # Replace with your solution name, i.e. MyWpfApp.sln.
+      Solution_Name: subs-check.win.gui.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
       Test_Project_Path: your-test-project-path                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
-      Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
+      Wap_Project_Directory: .    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
       Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
+      Configuration: ${{ matrix.configuration }}
 
     steps:
     - name: Checkout
@@ -79,18 +80,20 @@ jobs:
       with:
         dotnet-version: 8.0.x
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    # Add MSBuild to the PATH
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
 
     # Execute all unit tests in the solution
     - name: Execute unit tests
       if: github.event_name != 'release'
-      run: dotnet test
+      run: dotnet test $env:Solution_Name
 
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    # Restore the application
     - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+      run: |
+        dotnet restore $env:Solution_Name
+        msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
 
@@ -114,9 +117,9 @@ jobs:
       if: github.event_name == 'release'
       run: |
         $releaseDir = "release-package"
-        New-Item -ItemType Directory -Path $releaseDir
+        New-Item -ItemType Directory -Path $releaseDir -Force
         Copy-Item "bin\${{ matrix.configuration }}\*" -Destination $releaseDir -Recurse
-        Compress-Archive -Path "$releaseDir\*" -DestinationPath "SubsCheck-Win-GUI.zip"
+        Compress-Archive -Path "$releaseDir\*" -DestinationPath "SubsCheck-Win-GUI.zip" -Force
 
     # Upload release artifacts
     - name: Upload release artifacts
@@ -124,8 +127,6 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         files: SubsCheck-Win-GUI.zip
-        name: ${{ github.event.release.name }}
-        body: ${{ github.event.release.body }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,8 @@ jobs:
 
     # Upload build artifacts (for non-release builds)
     - name: Upload build artifacts
-      if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/v')
-      uses: actions/upload-artifact@v3
+      if: tartsWith(github.ref, 'refs/tags/v')
+      uses: actions/upload-artifact@v4
       with:
         name: Build Artifacts
         path: bin\${{ matrix.configuration }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,15 @@
 # For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
 # refer to https://github.com/microsoft/github-actions-for-desktop-apps
 
-name: .NET Core Desktop
+name: release CI
 
 on:
   push:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  release:
+    types: [created]
 
 jobs:
 
@@ -51,6 +53,10 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
+        # 仅在非 release 事件时包含 Debug 配置
+        include:
+          - configuration: Debug
+            if: github.event_name != 'release'
 
     runs-on: windows-latest  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
@@ -79,6 +85,7 @@ jobs:
 
     # Execute all unit tests in the solution
     - name: Execute unit tests
+      if: github.event_name != 'release'
       run: dotnet test
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
@@ -89,27 +96,43 @@ jobs:
 
     # Decode the base 64 encoded pfx and save the Signing_Certificate
     - name: Decode the pfx
+      if: github.event_name == 'release'
       run: |
         $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
         $certificatePath = Join-Path -Path $env:Wap_Project_Directory -ChildPath GitHubActionsWorkflow.pfx
         [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
 
-    # Create the app package by building and packaging the Windows Application Packaging project
-    - name: Create the app package
-      run: msbuild $env:Wap_Project_Path /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:Appx_Package_Build_Mode /p:AppxBundle=$env:Appx_Bundle /p:PackageCertificateKeyFile=GitHubActionsWorkflow.pfx /p:PackageCertificatePassword=${{ secrets.Pfx_Key }}
+    # Build the application
+    - name: Build the application
+      run: |
+        msbuild $env:Solution_Name /p:Configuration=$env:Configuration /p:Platform="Any CPU" /p:DebugSymbols=false /p:DebugType=None
       env:
-        Appx_Bundle: Always
-        Appx_Bundle_Platforms: x86|x64
-        Appx_Package_Build_Mode: StoreUpload
         Configuration: ${{ matrix.configuration }}
 
-    # Remove the pfx
-    - name: Remove the pfx
-      run: Remove-Item -path $env:Wap_Project_Directory\GitHubActionsWorkflow.pfx
+    # Create release package
+    - name: Create release package
+      if: github.event_name == 'release'
+      run: |
+        $releaseDir = "release-package"
+        New-Item -ItemType Directory -Path $releaseDir
+        Copy-Item "bin\${{ matrix.configuration }}\*" -Destination $releaseDir -Recurse
+        Compress-Archive -Path "$releaseDir\*" -DestinationPath "SubsCheck-Win-GUI.zip"
 
-    # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
+    # Upload release artifacts
+    - name: Upload release artifacts
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: SubsCheck-Win-GUI.zip
+        name: ${{ github.event.release.name }}
+        body: ${{ github.event.release.body }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Upload build artifacts (for non-release builds)
     - name: Upload build artifacts
+      if: github.event_name != 'release'
       uses: actions/upload-artifact@v4
       with:
-        name: MSIX Package
-        path: ${{ env.Wap_Project_Directory }}\AppPackages
+        name: Build Artifacts
+        path: bin\${{ matrix.configuration }}


### PR DESCRIPTION
# 使用方式
## 创建测试标签
git tag v0.0.1-test
## 推送标签到远程触发工作流(自动生成release版本)
git push origin v0.0.1-test